### PR TITLE
Fix build issues when building a library

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,8 +108,9 @@ module.exports = (neutrino) => {
       config
         .devtool('inline-source-map')
         .entry('index')
-        .add(`webpack-dev-server/client?${protocol}://${host}:${port}/`)
-        .add('webpack/hot/dev-server');
+          .prepend('webpack/hot/dev-server')
+          .prepend(`webpack-dev-server/client?${protocol}://${host}:${port}/`)
+          .end();
     }, config => {
       neutrino.use(clean, { paths: [neutrino.options.output] });
       neutrino.use(minify);


### PR DESCRIPTION
Hi,

I noticed some issues when running HMR while building a [library](https://webpack.js.org/guides/author-libraries/#add-librarytarget). The main issue is that the global object of my library was empty. I debugged this a bit and I found out that the issue was related to the order of files in webpack's entry.
So I suggest using `.prepend()` instead of `.add()` so that the actual entrypoint would be used in the global object even in HMR mode.
